### PR TITLE
polar_training2tcx fixes and improvements

### DIFF
--- a/polar_training2tcx
+++ b/polar_training2tcx
@@ -116,7 +116,7 @@ def output_tcx(parsed)
                       break
                     end
 
-                    break if i >= samples_count && i >= route_samples_count
+                    break if i >= samples_count && route_i >= route_samples_count
 
                     if !alt_offline || i > alt_offline.stop_index
                       alt_offline = samples.altitude_offline.find { |off| off.start_index == i } || false
@@ -173,7 +173,6 @@ def output_tcx(parsed)
                           }
                         }
                       end
-                      first_sample_with_gps = false if first_sample_with_gps
                     }.xmlns = 'http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2'
 
                     i += 1

--- a/polar_training2tcx
+++ b/polar_training2tcx
@@ -173,13 +173,13 @@ def output_tcx(parsed)
                           }
                         }
                       end
-                    }.xmlns = 'http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2'
+                    }
 
                     i += 1
                     elapsed += recording_interval
                     elapsed_with_pauses += recording_interval
                   end
-                }.xmlns = 'http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2'
+                }
               end
               if (avg_speed && avg_speed > 0) || (avg_watts && avg_watts > 0)
                 xml.Extensions {

--- a/polar_training2tcx
+++ b/polar_training2tcx
@@ -136,7 +136,7 @@ def output_tcx(parsed)
 
                     xml.Trackpoint {
                       xml.Time (start + elapsed_with_pauses).strftime("%Y-%m-%dT%H:%M:%S.%3NZ")
-                      if route_i && route_samples.duration[route_i] #&& (route_samples.duration[route_i] / 1000 <= elapsed)
+                      if route_i && route_samples.duration[route_i] && (route_samples.duration[route_i].to_f / 1000 <= elapsed)
                         xml.Position  {
                           xml.LatitudeDegrees route_samples.latitude[route_i].round(8)
                           xml.LongitudeDegrees route_samples.longitude[route_i].round(8)


### PR DESCRIPTION
I used the tools to get training data from Polar M430 and import to Strava (thanks a lot for this project BTW!). For the result to meet my needs, I had to do the changes as in this PR.

Commit 2726621 fixes the loop break condition (line 119) to check `route_i` as the route samples counter. Without the change, it could stop processing the data prematurely. Also, `first_sample_with_gps = false if first_sample_with_gps` (line 176) is removed as this variable is not used anywhere else.

Commit 881f3d1 removes the `xmlns` attribute from `<Track>` and `<Trackpoint>` (lines 177, 182 in the original code). It was the key to make Strava import the tracks successfully. I also checked that TCX files created with the PolarFlow app do not contain `xmlns` for these elements either.

Commit e979012 uncomments and slightly improves the check for route samples to match the currently processed time stamp (line 139). Without this change, all route samples are placed at the beginning of the training, ignoring the actual time of GPS [in]availability. There seem to be some differences with how PolarFlow handles it, but I feel matching the time stamps gives more accurate results.